### PR TITLE
Fix some of OST files having loading problem

### DIFF
--- a/src/XstReader.Api/NDB.cs
+++ b/src/XstReader.Api/NDB.cs
@@ -537,7 +537,13 @@ namespace XstReader
                         if (buffer == null)
                             buffer = new byte[rb.InflatedLength];
 
-                        decompressionStream.Read(buffer, offset, rb.InflatedLength);
+                        var writable = new MemoryStream(buffer, offset, rb.InflatedLength, true);
+                        decompressionStream.CopyTo(writable);
+
+                        if (writable.Position != writable.Length)
+                        {
+                            throw new EndOfStreamException();
+                        }
                     }
                     read = rb.InflatedLength;
                 }


### PR DESCRIPTION
Fix unfilled buffer of DeflateStream.Read which was brought by a .NET 6.0 beaking change.

Breaking change: Partial and zero-byte reads in DeflateStream, GZipStream, and CryptoStream - .NET | Microsoft Learn https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams