### PR TITLE
Added Filtering Capabilities to XstExporter and improvements to XstReader.Api

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ More information in [XstReader.md](./XstReader.md)
 A Command Line tool for exporting emails, attachments or properties from an Microsoft Outlook's .ost and .pst file:
 * With the ability to export from a subtree of Outlook folders
 * Can export attachments only, without the body of the email.
+* Can filter what is exported based off either the sender, subject, minimum time or maximum time the email was received (only in the Windows version for now).
 * Is built over .Net Framework 4.6.1 (for Windows)
 * There is a *Portable* version based on .Net Core 2.1 (cross-platform)
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -19,6 +19,14 @@
 **XstReader.Api v.1.0.2**:
 * Fixed error with intellisense in nuget package
 
+## 2023-07-23
+**XstEporter v2.0.8:
+* Added command line filters for XstExporter to be able to filter what is exported based off either the sender, subject, minimum time or maximum time the email was received. This only works with when exporting with '--email' or '--attachments' set ('--properties' will not work with the filters yes as the properties export is a lot faster and therefore wasn't a requirement just yet).
+
+**XstReader.Api v1.0.8
+* Fixed issue in GetBodyFormats where for items such as those in the folder "Recipient Cache" it wasn't getting the body format. It will now default to plaintext if no other formats found.
+* Added Sender SMTP Address (PidTagSenderSmtpAddress) to the Message properties.
+
 ## 2022-01-26
 **All projects**:
 * New folder structure for code

--- a/XstExporter.md
+++ b/XstExporter.md
@@ -7,8 +7,11 @@ The differences from the export capabilities of the UI are: the ability to expor
 
 In addition to XstExporter, XstExporter.Portable is also provided, which is a portable version based on .Net Core 2.1 that can be run on Windows, Mac, Linux etc. 
 
-Both versions support the following options:
+XstExporter supports the following options:
 
+   XstExport.exe {-e|-p|-a|-h} [-f=`<Outlook folder>`] [-se=<Sender>] [-su=<Subject>] [-mint=<Minimum time>] [-maxt=<Maximum time>] [-o] [-s] [-t=`<target directory>`] `<Outlook file name>`
+
+XstExporter.Portable support the following options (filtering capabilties to be added in later release):
    XstExporter.exe {-e|-p|-a|-h} [-f=`<Outlook folder>`] [-o] [-s] [-t=`<target directory>`] `<Outlook file name>`
 
 Where:
@@ -37,6 +40,20 @@ Where:
    -s, --subfolders  
       If set, Outlook subfolder structure is preserved.
       Otherwise, all output goes to a single directory
+   
+   -se, --sender
+      If set, Outlook will export based on the specified sender. This filter only applies when --email or --attachments is used, it will not filter for --properties.
+
+   -su, --subject
+      If set, Outlook will export based on the specified subject. This filter only applies when --email or --attachments is used, it will not filter for --properties.
+
+   -mint, --mintime
+      If set, Outlook will export emails only after the minimum time specified based on the email received time. This filter only applies when --email or --attachments is used, it will not filter for --properties.
+	  For example '2023-07-18 09:00:00' will export emails received after 9 AM on the 18th July 2023.
+
+   -maxt, --maxtime
+      If set, Outlook will export emails only before the maximum time specified based on the email received time. This filter only applies when --email or --attachments is used, it will not filter for --properties.
+	  For example '2023-07-18 09:00:00 will export emails received before 9 AM on the 18th July 2023.
 
    -t=`<target directory name>`, --target=`<target directory name>`  
       The directory to which output is written. This may be an

--- a/src/OldXstReader/XstMessageFormatter.cs
+++ b/src/OldXstReader/XstMessageFormatter.cs
@@ -43,7 +43,7 @@ namespace XstReader
                : "txt";
 
         private string _ExportFileName = null;
-        public string ExportFileName => _ExportFileName ?? (_ExportFileName = String.Format("{0:yyyy-MM-dd HHmm} {1}", Message?.Date, Message?.Subject).Truncate(150).ReplaceInvalidFileNameChars(" "));
+        public string ExportFileName => _ExportFileName ?? String.Format("{0:yyyy-MM-dd HHmm} {1}", Message?.Date, Message?.Subject).Truncate(150).ReplaceInvalidFileNameChars(" ");
 
         private XstRecipient OriginatorRecipient => Message.Recipients[RecipientType.Originator].FirstOrDefault();
         private IEnumerable<XstRecipient> ToRecipients => Message.Recipients[RecipientType.To];

--- a/src/XstExporter/XstExporter.csproj
+++ b/src/XstExporter/XstExporter.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net48</TargetFramework>
-    <Version>2.0.1</Version>
-    <AssemblyVersion>2.0.1</AssemblyVersion>
-    <FileVersion>2.0.1</FileVersion>
+    <Version>2.0.2</Version>
+    <AssemblyVersion>2.0.2</AssemblyVersion>
+    <FileVersion>2.0.2</FileVersion>
     <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/src/XstReader.Api/XstMessage.cs
+++ b/src/XstReader.Api/XstMessage.cs
@@ -107,13 +107,22 @@ namespace XstReader
         [Category(@"Message Properties")]
         [Description(@"Contains a list of the primary recipient display names, separated by semicolons, when an email message has primary recipients .")]
         public virtual string To => Properties[PropertyCanonicalName.PidTagDisplayTo]?.ValueAsStringSanitized;
-        /// <summary>
+        
+		/// <summary>
         /// The From Summary of the Message
         /// </summary>
         [DisplayName("Sender Name")]
         [Category(@"Address Properties")]
         [Description(@"Contains the display name of the sending mailbox owner.")]
         public virtual string From => Properties[PropertyCanonicalName.PidTagSenderName]?.ValueAsStringSanitized;
+		
+		/// <summary>
+        /// The From Summary of the Message
+        /// </summary>
+        [DisplayName("Sender SMTP Address")]
+        [Category(@"Address Properties")]
+        [Description(@"Contains the SMTP address of the sending mailbox owner.")]
+		public virtual string FromSmtpAddress => Properties[PropertyCanonicalName.PidTagSenderSmtpAddress]?.ValueAsStringSanitized;
 
         /// <summary>
         /// Indicates if the Message is sent in representation of other 
@@ -535,6 +544,8 @@ namespace XstReader
                 formatList.Add(XstMessageBodyFormat.Rtf);
             if (IsBodyPlainText)
                 formatList.Add(XstMessageBodyFormat.PlainText);
+			if (formatList.Count == 0)
+				formatList.Add(XstMessageBodyFormat.PlainText);
 
             return formatList;
         }

--- a/src/XstReader.Api/XstReader.Api.csproj
+++ b/src/XstReader.Api/XstReader.Api.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>XstReader</RootNamespace>
-    <Version>1.0.7</Version>
-    <AssemblyVersion>1.0.7</AssemblyVersion>
-    <FileVersion>1.0.7</FileVersion>
+    <Version>1.0.8</Version>
+    <AssemblyVersion>1.0.8</AssemblyVersion>
+    <FileVersion>1.0.8</FileVersion>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>iluvadev</Authors>


### PR DESCRIPTION
**XstEporter v2.0.8:
* Added command line filters for XstExporter to be able to filter what is exported based off either the sender, subject, minimum time or maximum time the email was received. This only works with when exporting with '--email' or '--attachments' set ('--properties' will not work with the filters yes as the properties export is a lot faster and therefore wasn't a requirement just yet).

**XstReader.Api v1.0.8
* Fixed issue in GetBodyFormats where for items such as those in the folder "Recipient Cache" it wasn't getting the body format. It will now default to plaintext if no other formats found.
* Added Sender SMTP Address (PidTagSenderSmtpAddress) to the Message properties.